### PR TITLE
Shouldn't Sage use the plugin and Bedrock use the package?

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ WordPress plugin containing modules to cleanup and customize wp-admin.
 
 Recommended method/s;
 
-[Roots Bedrock](https://roots.io/bedrock/) and [WP-CLI](http://wp-cli.org/)
+[Roots Bedrock](https://roots.io/bedrock/)
+```shell
+$ composer require soberwp/intervention:1.2.0-p
+```
+
+[Roots Sage](https://roots.io/sage/) and [WP-CLI](http://wp-cli.org/)
 ```shell
 $ composer require soberwp/intervention
 $ wp plugin activate intervention
-```
-
-[Roots Sage](https://roots.io/sage/)
-```shell
-$ composer require soberwp/intervention:1.2.0-p
 ```
 
 #### Manual:


### PR DESCRIPTION
Correct me if I'm wrong but shouldn't Sage use the `master` branch (plugin) and Bedrock (composer, autoload) use the `package` branch (package)?